### PR TITLE
Added error checking for appPath being a numerical type in init.js

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -32,7 +32,7 @@ var InitCommand = Class(BaseCommand, function (supr) {
       var appPath = args.shift();
       var errorMessage;
 
-      if (!appPath) {
+      if (typeof(appPath) === 'undefined') {
         // TODO: print usage
         errorMessage = 'No app name provided';
         this.logger.error(errorMessage);


### PR DESCRIPTION
Should fix [issue 84](https://github.com/gameclosure/devkit2/issues/84). The problem arose from the appPath variable being stored as the numerical value 0 and therefore evaluating to false in the error check following the change (that proceeds the normal error check for the integrity of the app name).