### PR TITLE
Handle basic refs in getHashForRef

### DIFF
--- a/src/util/gitClient/functions.js
+++ b/src/util/gitClient/functions.js
@@ -316,7 +316,9 @@ exports.getHashForRef = function getHashForRef (ref, cb) {
   return this('show-ref', ref).bind(this)
   .catch(handleShowRefVerifyError)
   .then(function findMostCurrentRef(refs) {
+    trace('refs', refs);
     refs = parseShowRefOutput(refs);
+
     var remote = refs.filter(function (refInfo) {
       return refInfo.remote && refInfo.ref === ref;
     })[0];
@@ -330,14 +332,15 @@ exports.getHashForRef = function getHashForRef (ref, cb) {
     })[0];
 
     trace('local', local);
+    if (local) { return local.hash; }
 
-    if (!local) {
+    // See if ref is a valid hash
+    return this('rev-parse', ref).then(function isRef(res) {
+      return ref;
+    }).catch(function () {
       return Promise.reject(new UnknownGitRevision(ref));
-    }
+    });
 
-
-    trace('returning local hash');
-    return local.hash;
   }).nodeify(cb);
 };
 


### PR DESCRIPTION
md5 ref hashes were not handled properly in the past. If we fail to
parse the ref as a branch or tag, we now try to simply parse the ref as
a revision hash. This is done after the ref checking since branches
cannot be detected in this fashion.